### PR TITLE
Add Option KZ(22)=10 for input data with astronomical unit

### DIFF
--- a/src/Main/data.F
+++ b/src/Main/data.F
@@ -28,7 +28,8 @@
       if(rank.eq.0)then
 *
       IREAD = 0
-      IF (KZ(22).EQ.2.OR.KZ(22).EQ.6.OR.KZ(22).EQ.9) THEN
+      IF (KZ(22).EQ.2.OR.KZ(22).EQ.6.OR.
+     &     KZ(22).EQ.9.OR.KZ(22).EQ.10) THEN
           DO 5 I = 1,N
               READ (10,*)  BODY(I), (X(K,I),K=1,3), (XDOT(K,I),K=1,3)
     5     CONTINUE

--- a/src/Main/scale.F
+++ b/src/Main/scale.F
@@ -69,16 +69,22 @@
                BODY(I) = BODY(I)/ZMASS
  50         CONTINUE
          END IF
-*     
+*
+*     Determine astronomical scale from original data
+*     Assume Mass use the unit of M_sun 
+         IF(KZ(22).EQ.10) ZMBAR = ZMASS/FLOAT(N)
+         
          ZMASS = 1.D0
 *
       END IF
 *
+      GRAV = 1.0D0
+*     Astronomical unit in non-scaled input data
+      IF (LSCALE) GRAV = 4.30145D-3*ZMBAR*FLOAT(N)
+      
 *     --10/22/13 17:12-lwang-binary-scale-------------------------------*
 ***** Note:------------------------------------------------------------**
-*      GRAV = GRAV*SUNM/PARSEC/1.D10*ZMBAR*FLOAT(N)
       IF (KZ(8).EQ.2) THEN
-         GRAV = 4.30145D-3*ZMBAR*FLOAT(N)
 *       Sum the total energy of pairs.
          NPAIRS = NBIN0
          IFIRST = 2*NPAIRS + 1
@@ -200,6 +206,12 @@
 *       Scale non-zero velocities by virial theorem ratio.
 *       (if start model data were read from other source do NOT scale)(R.Sp.)
       ELSE IF (LSCALE) THEN
+*     Determine Q from original data and initialize VSTAR
+         IF (KZ(22).EQ.10) THEN
+            Q = ZKIN/(GRAV*VIR)
+            QVIR = Q
+            VSTAR = 1.0D0
+         END IF
          IF (ZKIN.GT.0.0D0) THEN
             QV = SQRT(Q*VIR/ZKIN)
             DO 60 I = 1,N
@@ -207,6 +219,7 @@
                   XDOT(K,I) = XDOT(K,I)*QV
  58            CONTINUE
  60         CONTINUE
+            IF (KZ(22).EQ.10) VSTAR = 1.0D0/QV
          END IF
 *
 *     Scale total energy to standard units (E = -0.25 for Q < 1).
@@ -227,6 +240,13 @@
                XDOT(K,I) = XDOT(K,I)*SQRT(SX)
  68         CONTINUE
  70      CONTINUE
+*     Determine astronomical scale from original data
+*     Assume original data use M_sun, PC and km/s as units
+         IF (KZ(22).EQ.10) THEN
+            VSTAR = VSTAR/SQRT(SX)
+            RBAR = SX
+         END IF
+         
       ELSE
          ETOT = ZKIN - POT
          E0 = ETOT
@@ -234,9 +254,11 @@
 
 *     Print scaling information
       if(rank.eq.0)
-     *     WRITE (6,65)  SX, ETOT, BODY(1), BODY(N), ZMASS/FLOAT(N)
+     *     WRITE (6,65)  SX, ETOT, BODY(1), BODY(N), ZMASS/FLOAT(N),
+     &     Q
  65   FORMAT (//,12X,'SCALING:   SX =',1P,D13.5,'  E =',E10.2,
-     &     '  M(1) =',E9.2,'  M(N) =',E9.2,'  <M> =',E9.2)
+     &     '  M(1) =',E9.2,'  M(N) =',E9.2,'  <M> =',E9.2,
+     &     '  Q =',0P,F10.5)
 *     
       call flush(6)
 

--- a/src/Main/start.F
+++ b/src/Main/start.F
@@ -34,7 +34,12 @@
 *
 *       Define mean mass in scaled units and solar mass conversion factor.
       BODYM = ZMASS/FLOAT(N)
-      ZMBAR = ZMBAR/BODYM
+*     Notice from now ZMBAR is mass scale factor instead of average mass of input data
+      IF (KZ(22).NE.10) THEN
+         ZMBAR = ZMBAR/BODYM
+      ELSE
+         ZMBAR = ZMBAR*FLOAT(N)
+      END IF
 *
 *       Introduce scaling factors DAYS, YRS, SU, RAU, SMU, TSTAR & VSTAR.
       CALL UNITS

--- a/src/Main/units.f
+++ b/src/Main/units.f
@@ -23,20 +23,26 @@
 *       Copy solar mass scaling to new variable (M = BODY*<M>).
       SMU = ZMBAR
 *
-*       Form time scale in seconds and velocity scale in km/sec.
+*     Form time scale in seconds and velocity scale in km/sec.
       TSTAR = SQRT(PC/GM)*PC
-      VSTAR = 1.0D-05*SQRT(GM/PC)
-*
-*       Convert time scale from units of seconds to million years.
+
+*     Convert time scale from units of seconds to million years.
       TSTAR = TSTAR/(3.15D+07*1.0D+06)
+
+      IF (KZ(22).NE.10) THEN
+         VSTAR = 1.0D-05*SQRT(GM/PC)
 *
 *       Ensure ZMBAR & RBAR > 0 (=0: assume <M>/Sun = 1, RBAR = 1 pc).
-      IF (ZMBAR.LE.0.0D0) ZMBAR = FLOAT(N)/ZMASS
-      IF (RBAR.LE.0.0D0) RBAR = 1.0
+         IF (ZMBAR.LE.0.0D0) ZMBAR = FLOAT(N)/ZMASS
+         IF (RBAR.LE.0.0D0) RBAR = 1.0
 *
 *       Scale to working units of RBAR in pc & ZMBAR in solar masses.
-      TSTAR = TSTAR*SQRT(RBAR**3/(ZMASS*ZMBAR))
-      VSTAR = VSTAR*SQRT(ZMASS*ZMBAR/RBAR)
+         TSTAR = TSTAR*SQRT(RBAR**3/(ZMASS*ZMBAR))
+         VSTAR = VSTAR*SQRT(ZMASS*ZMBAR/RBAR)
+      ELSE
+*     USE scale factor from original input data instead
+         TSTAR = TSTAR*SQRT(RBAR**3/ZMBAR)
+      END IF
 *
 *       Copy TSTAR to secondary time-scale factor.
       TSCALE = TSTAR


### PR DESCRIPTION
When KZ(22)=10 is used, NBODY format data (mass, position, velocity) will be read from dat.10. The units of input data are astronomical units (mass: M_sun; position: pc; velocity: km/s).
The scaling factors (RBAR, VSTAR, TSTAR, ZMBAR) and virial ratio Q will be obtained directly from the data in dat.10 instead of values from input file.
This means the input variables (RBAR, Q, ZMBAR) will be suppressed.

Notice when KZ(14)>0 and RTIDE>0, the scaling factors will be modified (the new values will be shown in the main output)Nbody6ppGPU